### PR TITLE
Add RedHat verification to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,11 @@ CHARTS := $(wildcard $(CHARTS_DIR)/*/Chart.yaml)
 LINT_CMD := helm lint
 SCHEMA_CMD := helm schema-gen
 PACKAGE_CMD := helm package
+VERIFY_CMD := docker run --rm -v $$(pwd):/charts:z \
+	quay.io/redhat-certification/chart-verifier verify
 
 # Targets
-.PHONY: all lint schema package
+.PHONY: all lint schema package verify-redhat
 
 all: lint schema package
 
@@ -20,4 +22,10 @@ package:
 	@for chart in $(CHARTS); do \
 		echo "Packaging $$(dirname $$chart)..."; \
 		$(PACKAGE_CMD) $$(dirname $$chart); \
+	done
+
+verify-redhat:
+	@for chart in $(wildcard ./*.tgz); do \
+		echo "Verifying package $$chart..."; \
+		$(VERIFY_CMD) /charts/$$chart; \
 	done


### PR DESCRIPTION
**Description** <Describe what changed.>
This PR adds the RedHat verification to the Makefile. This is just the beginning of configuring it.

**Testing** <Describe how you tested the change.>
Tested Locally.

Output:
```
Verifying package ./orchestrator-0.1.1.tgz...
apiversion: v1
kind: verify-report
metadata:
    tool:
        verifier-version: 1.12.2
        profile:
            VendorType: partner
            version: v1.2
        reportDigest: uint64:4469591665659353843
        chart-uri: /charts/./orchestrator-0.1.1.tgz
        digests:
            chart: sha256:b7500a9a75906c2c62b1ff700cac01fdc0bdafdef49828398310f3400fe9049a
            package: 7e17c0d9f93751141398a060e2398401cef06a89cc56a2811e5e6e9f63437336
        lastCertifiedTimestamp: "2023-08-12T03:17:16.578551+00:00"
        testedOpenShiftVersion: N/A
        supportedOpenShiftVersions: N/A
        webCatalogOnly: false
    chart:
        name: orchestrator
        home: https://www.strata.io/
        sources: []
        version: 0.1.1
        description: 'Maverics Identity Orchestrator (also referred to as an "Orchestrator") is a distributed identity management platform that abstracts authentication and session management, connects to any identity/attribute system, replicates and synchronizes policies and configurations. '
        keywords:
            - identity
            - orchestration
            - authentication
            - authorization
            - idp
            - oidc
            - saml
            - webauthn
            - cybersecurity
            - mesh
        maintainers:
            - name: gramidt
              email: granville@strata.io
              url: ""
        icon: https://raw.githubusercontent.com/strata-io/helm-charts/main/assets/logo_maverics.png
        apiversion: v2
        condition: ""
        tags: ""
        appversion: 0.23.31
        deprecated: false
        annotations: {}
        kubeversion: ""
        dependencies: []
        type: application
    chart-overrides: ""
results:
    - check: v1.0/required-annotations-present
      type: Mandatory
      outcome: FAIL
      reason: 'Missing required annotations: [charts.openshift.io/name]'
    - check: v1.0/chart-testing
      type: Mandatory
      outcome: FAIL
      reason: 'invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable'
    - check: v1.0/contains-test
      type: Mandatory
      outcome: PASS
      reason: Chart test files exist
    - check: v1.0/contains-values
      type: Mandatory
      outcome: PASS
      reason: Values file exist
    - check: v1.0/has-readme
      type: Mandatory
      outcome: PASS
      reason: Chart has a README
    - check: v1.0/helm-lint
      type: Mandatory
      outcome: PASS
      reason: Helm lint successful
    - check: v1.0/not-contain-csi-objects
      type: Mandatory
      outcome: PASS
      reason: CSI objects do not exist
    - check: v1.0/is-helm-v3
      type: Mandatory
      outcome: PASS
      reason: API version is V2, used in Helm 3
    - check: v1.1/has-kubeversion
      type: Mandatory
      outcome: FAIL
      reason: Kubernetes version is not specified
    - check: v1.0/not-contains-crds
      type: Mandatory
      outcome: PASS
      reason: Chart does not contain CRDs
    - check: v1.0/contains-values-schema
      type: Mandatory
      outcome: PASS
      reason: Values schema file exist
    - check: v1.0/signature-is-valid
      type: Mandatory
      outcome: SKIPPED
      reason: 'Chart is not signed : Signature verification not required'
    - check: v1.1/images-are-certified
      type: Mandatory
      outcome: FAIL
      reason: |-
        Image is not Red Hat certified : busybox : repository not found: busybox
        Image is not Red Hat certified : maverics:0.23.31 : repository not found: maverics
```

**Documentation** <Describe any documentation that was added.>
N/A