### PR TITLE
Add RedHat Marketplace Verification workflow

### DIFF
--- a/.github/workflows/redhat-verification.yml
+++ b/.github/workflows/redhat-verification.yml
@@ -1,0 +1,27 @@
+name: RedHat Marketplace Verification
+
+on: pull_request
+
+jobs:
+  verify-chart:
+    # Disabled until the Orchestrator Image is available in the RedHat Marketplace
+    # and an OpenShift cluster is available for automated testing.
+    if: ${{ false }}
+    name: Verify Helm Chart
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: redhat-actions/oc-login@v1
+        with:
+          openshift_server_url: ${{ secrets.OPENSHIFT_SERVER }}
+          openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}
+
+        # Install chart-verifier CLI
+      - uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          source: github
+          chart-verifier: latest
+
+      - uses: redhat-actions/chart-verifier@v1.0.0
+        with:
+          chart_uri: https://github.com/redhat-actions/openshift-actions-runner-chart/blob/release-chart/packages/actions-runner-1.1.tgz?raw=true
+          verify_args: --chart-set githubOwner=redhat-actions


### PR DESCRIPTION
**Description** <Describe what changed.>
This PR adds a disabled RedHat Marketplace Verification workflow. It should be enabled once the Orchestrator image has been certified and available within the RedHat Marketplace/registry.

**Testing** <Describe how you tested the change.>
N/A

**Documentation** <Describe any documentation that was added.>
* https://github.com/redhat-actions/chart-verifier
* https://github.com/redhat-certification/chart-verifier/blob/main/docs/helm-chart-checks.md