### PR TITLE
Update pods on config change

### DIFF
--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time we
 # make changes to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.5
 
 # This is the version number of the application being deployed. This version number
 # should be incremented each time we make changes to the application. Versions are

--- a/charts/orchestrator/templates/statefulset.yaml
+++ b/charts/orchestrator/templates/statefulset.yaml
@@ -17,10 +17,11 @@ spec:
     type: {{ .Values.updateStrategy }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+      {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       labels:
         {{- include "orchestrator.selectorLabels" . | nindent 8 }}
     spec:


### PR DESCRIPTION
**Description** <Describe what changed.>
This PR ensures that Orchestrators are restarted when the config changes. This is different from config reloading when using an external bucket for config.

Note: This could eventually be configurable, so it can be toggled off when `MAVERICS_RELOAD_CONFIG: true`; however, this setting is commonly used with remote config, so this toggle was omitted for the near-term fix.

**Testing** <Describe how you tested the change.>
Tested against a cluster.

**Documentation** <Describe any documentation that was added.>
N/A