### PR TITLE
Fix stateful set environment variables

### DIFF
--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time we
 # make changes to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.10
+version: 0.1.11
 
 # This is the version number of the application being deployed. This version number
 # should be incremented each time we make changes to the application. Versions are

--- a/charts/orchestrator/templates/statefulset.yaml
+++ b/charts/orchestrator/templates/statefulset.yaml
@@ -78,6 +78,7 @@ spec:
             {{ end }}
             - name: MAVERICS_GROUPS_PRIMARY_NODE_KEY_FILE
               value: /etc/maverics/groups/tls/primary-key
+            {{- end }}
             {{- range $key, $value := .Values.env }}
             - name: "{{ tpl $key $ }}"
               value: "{{ tpl (print $value) $ }}"
@@ -86,7 +87,6 @@ spec:
             - name: {{ $key | quote }}
               valueFrom:
                 {{- tpl (toYaml $value) $ | nindent 16 }}
-            {{- end }}
             {{- end }}
           {{- if or .Values.envFromSecrets .Values.envFromConfigMaps}}
           envFrom:


### PR DESCRIPTION
**Description** When disabling orchestrator groups, the end to that if condition wasn't properly scoped and included the env and envValueFrom sections

**Testing** `helm template` and viewed the output with a values file that contained `env` and `envValueFrom` sections.

**Documentation** N/A