### PR TITLE
Update helm/chart-testing-action to 2.6.1

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -22,7 +22,7 @@ jobs:
           check-latest: true
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.4.0
+        uses: helm/chart-testing-action@v2.6.1
 
       - name: Run chart-testing (list-changed)
         id: list-changed


### PR DESCRIPTION
**Description**
Updating the github action step for `helm/chart-testing-action` to the 2.6.1 as it's the latest version and the current version seems to no longer work.

**Testing**
Action is ran on this pr and successfully finished.

**Documentation**
N/A