### PR TITLE
Add Support For Kubernets 1.21 and above

### DIFF
--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time we
 # make changes to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.11
+version: 0.1.12
 
 # This is the version number of the application being deployed. This version number
 # should be incremented each time we make changes to the application. Versions are

--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -37,7 +37,7 @@ appVersion: "0.23.45"
 # required by RedHat Marketplace for certification of the chart.
 #
 # Before changing this value, please check compatibility with customer deployments.
-kubeVersion: '>=1.24.0'
+kubeVersion: '>=1.21.0'
 
 keywords:
   - identity

--- a/charts/orchestrator/README.md
+++ b/charts/orchestrator/README.md
@@ -9,17 +9,20 @@ manager.
 
 ## Table of contents
 
-- [Prerequisites](#prerequisites)
-- [Install](#install)
-- [Upgrade](#upgrade)
-- [Uninstall](#uninstall)
-- [FAQs](#faqs)
-- [Deployment Options](#deployment-options)
-- [Configuration](#configuration)
+- [Maverics Orchestrator for Kubernetes](#maverics-orchestrator-for-kubernetes)
+  - [Table of contents](#table-of-contents)
+  - [Prerequisites](#prerequisites)
+  - [Add and Update Repo](#add-and-update-repo)
+  - [Install](#install)
+  - [Upgrade](#upgrade)
+  - [Uninstall](#uninstall)
+  - [FAQs](#faqs)
+  - [Deployment Options](#deployment-options)
+  - [Configuration](#configuration)
 
 ## Prerequisites
 
-Kubernetes: `>=1.20.0-0`
+Kubernetes: `>=1.21.0-0`
 
 ## Add and Update Repo
 

--- a/charts/orchestrator/templates/statefulset.yaml
+++ b/charts/orchestrator/templates/statefulset.yaml
@@ -8,7 +8,12 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  {{- if semverCompare ">=1.22-0" .Capabilities.KubeVersion.GitVersion }}
   minReadySeconds: 2
+  {{- end}}
+  {{- if semverCompare "<=1.24-0" .Capabilities.KubeVersion.GitVersion }}
+  serviceName: {{ include "orchestrator.fullname" . }}
+  {{- end}}
   selector:
     matchLabels:
       {{- include "orchestrator.selectorLabels" . | nindent 6 }}

--- a/charts/orchestrator/templates/statefulset.yaml
+++ b/charts/orchestrator/templates/statefulset.yaml
@@ -8,10 +8,10 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
-  {{- if semverCompare ">=1.22-0" .Capabilities.KubeVersion.GitVersion }}
+  {{- if semverCompare ">=1.22-0" .Capabilities.KubeVersion.Version }}
   minReadySeconds: 2
   {{- end}}
-  {{- if semverCompare "<=1.24-0" .Capabilities.KubeVersion.GitVersion }}
+  {{- if semverCompare "<=1.24-0" .Capabilities.KubeVersion.Version }}
   serviceName: {{ include "orchestrator.fullname" . }}
   {{- end}}
   selector:


### PR DESCRIPTION
**Description**
This adds in support for Kubernetes 1.21.0 and above by adding a few tweaks to dynamically use specific version supported fields.

For versions 1.21.0 -> 1.24.0:  The `serviceName` field is required and without it will cause the helm install to fail
For versions 1.22.0 and above: The `minReadySeconds`  is supported and included

**Testing**
Validated locally using minikube against all versions between and including 1.21.0 -> 1.25.0 by doing a helm install dry run.

**Documentation**
No documentation needed as this is detected by the version of kubernetes.