### PR TITLE
Orchestrator Configmap Override

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,7 @@ The documentation for the Maverics Orchestrator Helm Chart is available
 ## Support
 If you run into an issue, bug or have a question, please reach out to the [Strata
 Identity team](https://www.strata.io/company/contact/).
+
+## Testing
+Tested locally using `helm template` to validate the output is as expected under different scenarios of values.
+`helm template charts/orchestrator --values charts/orchestrator/example-values/minimal-orchestrator-custom-configmap.yaml`

--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time we
 # make changes to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.12
+version: 0.1.13
 
 # This is the version number of the application being deployed. This version number
 # should be incremented each time we make changes to the application. Versions are

--- a/charts/orchestrator/README.md
+++ b/charts/orchestrator/README.md
@@ -19,6 +19,8 @@ manager.
   - [FAQs](#faqs)
   - [Deployment Options](#deployment-options)
   - [Configuration](#configuration)
+  - [Troubleshooting](#troubleshooting)
+    - [Pod Won't Start](#pod-wont-start)
 
 ## Prerequisites
 
@@ -72,4 +74,18 @@ See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_h
 
 ```console
 helm show values strata/orchestrator
+```
+
+## Troubleshooting
+### Pod Won't Start
+If the pod will not start you can validate the reason using the following command
+```console
+kubectl describe pod [RELEASE_NAME]-orchestrator-0 
+```
+
+At the bottom under `Events:` you should be able to see output similiar to below
+```console
+  Type     Reason       Age                   From               Message
+  ----     ------       ----                  ----               -------
+  Warning  FailedMount  119s (x10 over 6m9s)  kubelet            MountVolume.SetUp failed for volume "orchestrator-config" : configmap "myCustomConfig" not found
 ```

--- a/charts/orchestrator/example-values/README.md
+++ b/charts/orchestrator/example-values/README.md
@@ -3,10 +3,24 @@
 The YAML files in this directory provide basic example configurations for common 
 Orchestrator deployment scenarios on Kubernetes.
 
-* [minimal-orchestrator-openshift.yaml](./minimal-orchestrator-openshift.yaml) TODO
+* [minimal-orchestrator-openshift.yaml](./minimal-orchestrator-openshift.yaml) 
+  
+  TODO
 
-* [minimal-orchestrator-standalone-cloud-local-config.yaml](./minimal-orchestrator-standalone-cloud-local-config.yaml) TODO
+* [minimal-orchestrator-standalone-cloud-local-config.yaml](./minimal-orchestrator-standalone-cloud-local-config.yaml) 
+  
+  TODO
 
 * [minimal-orchestrator-standalone.yaml](./minimal-orchestrator-standalone.yaml) 
-installs a bare-minimal single instance Orchestrator. This is useful as a basic 
+
+    This examplee installs a bare-minimal single instance Orchestrator. This is useful as a basic 
 starter template.
+
+* [minimal-orchestrator-custom-configmap.yaml](./minimal-orchestrator-custom-configmap.yaml) 
+  
+    This example describes how to link an ConfigMap which contains Maverics Orchestrator yaml configuration.
+
+    Example of generating a ConfigMap from a custom ConfigMap object from a local config file.
+
+    ```kubectl create configmap mycustomconfig --from-file=maverics.yml=/etc/maverics/maverics-k8s.yaml```
+

--- a/charts/orchestrator/example-values/minimal-orchestrator-custom-configmap.yaml
+++ b/charts/orchestrator/example-values/minimal-orchestrator-custom-configmap.yaml
@@ -1,0 +1,12 @@
+image:
+  repository: alpine
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: latest
+
+replicaCount: 1
+
+orchestrator:
+  # The name of the ConfigMap to use for the custom Maverics Orchestrator configuration.
+  # If defined, it will be used instead of the baseConfig and customConfig.
+  customConfigMapName: mycustomconfig

--- a/charts/orchestrator/templates/configmap.yaml
+++ b/charts/orchestrator/templates/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.orchestrator.customConfig.useCustomConfigMap }}
+{{- if not .Values.orchestrator.customConfigMapName }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/orchestrator/templates/configmap.yaml
+++ b/charts/orchestrator/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.orchestrator.customConfig.useCustomConfigMap }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,6 +8,7 @@ metadata:
 data:
   maverics.yml: |
     {{- include "orchestrator.deploymentConfig" . | nindent 4 -}}
+{{- end}}
 ---
 {{ if and .Values.cloud.enabled (and .Values.cloud.config.createConfig) }}
 apiVersion: v1

--- a/charts/orchestrator/templates/statefulset.yaml
+++ b/charts/orchestrator/templates/statefulset.yaml
@@ -8,7 +8,7 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
-  {{- if semverCompare ">=1.22-0" .Capabilities.KubeVersion.Version }}
+  {{- if semverCompare ">=1.22-0" .Capabilities.KubeVersion.Version }}s
   minReadySeconds: 2
   {{- end}}
   {{- if semverCompare "<=1.24-0" .Capabilities.KubeVersion.Version }}
@@ -142,7 +142,11 @@ spec:
       volumes:
         - name: orchestrator-config
           configMap:
-            name: {{ template "orchestrator.fullname" . }}-config
+             {{- if .Values.orchestrator.customConfig.useCustomConfigMap }}
+             name: {{ .Values.orchestrator.customConfig.useCustomConfigMap.name }}
+             {{- else }}
+             name: {{ template "orchestrator.fullname" . }}-config
+            {{- end }}
         {{- if .Values.cloud.enabled }}
         - name: cloud-config
           configMap:

--- a/charts/orchestrator/templates/statefulset.yaml
+++ b/charts/orchestrator/templates/statefulset.yaml
@@ -146,7 +146,7 @@ spec:
              name: {{ .Values.orchestrator.customConfig.useCustomConfigMap.name }}
              {{- else }}
              name: {{ template "orchestrator.fullname" . }}-config
-            {{- end }}
+             {{- end }}
         {{- if .Values.cloud.enabled }}
         - name: cloud-config
           configMap:

--- a/charts/orchestrator/templates/statefulset.yaml
+++ b/charts/orchestrator/templates/statefulset.yaml
@@ -142,11 +142,11 @@ spec:
       volumes:
         - name: orchestrator-config
           configMap:
-            {{- if .Values.orchestrator.customConfig.useCustomConfigMap }}
-            name: {{ .Values.orchestrator.customConfig.useCustomConfigMap.name }}
-            {{- else }}
-            name: {{ template "orchestrator.fullname" . }}-config
-            {{- end }}
+             {{- if .Values.orchestrator.customConfigMapName }}
+             name: {{ .Values.orchestrator.customConfigMapName }}
+             {{- else }}
+             name: {{ template "orchestrator.fullname" . }}-config
+             {{- end }}
         {{- if .Values.cloud.enabled }}
         - name: cloud-config
           configMap:

--- a/charts/orchestrator/templates/statefulset.yaml
+++ b/charts/orchestrator/templates/statefulset.yaml
@@ -8,7 +8,7 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
-  {{- if semverCompare ">=1.22-0" .Capabilities.KubeVersion.Version }}s
+  {{- if semverCompare ">=1.22-0" .Capabilities.KubeVersion.Version }}
   minReadySeconds: 2
   {{- end}}
   {{- if semverCompare "<=1.24-0" .Capabilities.KubeVersion.Version }}

--- a/charts/orchestrator/templates/statefulset.yaml
+++ b/charts/orchestrator/templates/statefulset.yaml
@@ -142,11 +142,11 @@ spec:
       volumes:
         - name: orchestrator-config
           configMap:
-             {{- if .Values.orchestrator.customConfig.useCustomConfigMap }}
-             name: {{ .Values.orchestrator.customConfig.useCustomConfigMap.name }}
-             {{- else }}
-             name: {{ template "orchestrator.fullname" . }}-config
-             {{- end }}
+            {{- if .Values.orchestrator.customConfig.useCustomConfigMap }}
+            name: {{ .Values.orchestrator.customConfig.useCustomConfigMap.name }}
+            {{- else }}
+            name: {{ template "orchestrator.fullname" . }}-config
+            {{- end }}
         {{- if .Values.cloud.enabled }}
         - name: cloud-config
           configMap:

--- a/charts/orchestrator/values.schema.json
+++ b/charts/orchestrator/values.schema.json
@@ -248,6 +248,9 @@
                 "customConfig": {
                     "type": "object"
                 },
+                "customConfigMapName": {
+                    "type": "string"
+                },
                 "groups": {
                     "type": "object",
                     "properties": {

--- a/charts/orchestrator/values.yaml
+++ b/charts/orchestrator/values.yaml
@@ -216,6 +216,10 @@ orchestrator:
   # baseConfig.
   customConfig: {}
 
+  # The name of the ConfigMap to use for the custom Maverics Orchestrator configuration.
+  # If defined, it will be used instead of the baseConfig and customConfig.
+  customConfigMapName: ""
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
**Description**
This adds the ability to use a custom configmap instead of the baseConfig and customConfig in the values files. This allows passing in templated values (Ex: `{{ printf "{{ env.TEST_ENV_VAR}}" }}` ) to the orchestrator without having to do any escaping.

Example of using a custom configmap
```
  customConfig:
    useCustomConfigMap:
     name: orch-configmap-custom
```

Example of generating a configmap from a custom config yaml file.
`kubectl create configmap orch-configmap-custom --from-file=maverics.yaml=customConfig.yaml`

Example customConfig.yaml
```
version: 0.0.3

logger:
  level: debug

http:
  address: {{ env.MAVERICS_HTTP_ADDRESS}}
  ```
**Testing**
Tested locally using `helm template` to validate the output is as expected under different scenarios of values.

**Scenario 1**
useCustomConfigMap defined
```  
customConfig:
  useCustomConfigMap:
   name: orch-configmap-custom
```

Results in
```
volumes:
  - name: orchestrator-config
    configMap:
       name: orch-configmap-custom
```

**Scenario 2**
customConfig defined
```
  customConfig:
    version: 0.0.3

    logger:
      level: debug
```
Results in
```
volumes:
  - name: orchestrator-config
    configMap:
       name: release-name-orchestrator-config
```

**Scenario 3**
No customConfig defined

Results in
```
volumes:
  - name: orchestrator-config
    configMap:
       name: release-name-orchestrator-config
```


**Documentation** 
No additional documentation added.