### PR TITLE
[StorageProvider] Use quote function for env var values to support json

### DIFF
--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time we
 # make changes to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.13
+version: 0.1.14
 
 # This is the version number of the application being deployed. This version number
 # should be incremented each time we make changes to the application. Versions are

--- a/charts/orchestrator/README.md
+++ b/charts/orchestrator/README.md
@@ -15,6 +15,7 @@ manager.
   - [Add and Update Repo](#add-and-update-repo)
   - [Install](#install)
   - [Upgrade](#upgrade)
+  - [Example Values](#example-values)
   - [Uninstall](#uninstall)
   - [FAQs](#faqs)
   - [Deployment Options](#deployment-options)
@@ -54,6 +55,10 @@ helm upgrade [RELEASE_NAME] strata/orchestrator --namespace [NAMESPACE]
 ```
 
 _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
+
+## Example Values
+
+Example values files can be found under [example-values/README.md](example-values/README.md).
 
 ## Uninstall
 ```console

--- a/charts/orchestrator/example-values/README.md
+++ b/charts/orchestrator/example-values/README.md
@@ -24,3 +24,54 @@ starter template.
 
     ```kubectl create configmap mycustomconfig --from-file=maverics.yml=/etc/maverics/maverics-k8s.yaml```
 
+* [minimal-orchestrator-standalone-cloud-s3.yaml](./minimal-orchestrator-standalone-cloud-s3.yaml)
+  This example describes how to configure the helm chart to use a shared storage provider such as an S3 bucket, github, etc for the maverics configuration bundle.
+
+  For more information on supported shared providers, [https://developer.strata.io/orchestrator/setup/remote-config](https://developer.strata.io/orchestrator/setup/remote-config)
+
+  
+
+  Example of using inline
+  ```
+  env: 
+  MAVERICS_AWS_CONFIG: '{"accessKeyID":"my-access-key-id","bucketName":"my-bucket-name","configurationFilePath":"my-configuration-file-path","region":"us-east-2","secretAccessKey":"my-secret-access-key"}'
+    
+  cloud:
+    enabled: true
+    createConfig: true
+    config:
+      bundlePublicKeyB64: "LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUZrd0V3W="
+  ```
+
+  Example of using a secret
+  ```
+  envValueFrom:
+  MAVERICS_AWS_CONFIG:
+    secretKeyRef:
+      name: storage-provider-secret
+      key: config.json
+
+  cloud:
+    enabled: true
+    createConfig: true
+    config:
+      bundlePublicKeyB64: "LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUZrd0V3W="
+  ```
+
+  Example of the secret manifest
+  ```
+  apiVersion: v1
+  kind: Secret
+  metadata:
+    name: storage-provider-secret
+  type: Opaque
+  stringData:
+    config.json: |
+      {
+        "bucketName": "maverics-development",
+        "accessKeyID": "aws-access-key-id",
+        "secretAccessKey": "aws-secret-access-key",
+        "region": "aws-region",
+        "configurationFilePath": "folder1/folder2"
+      }
+  ```

--- a/charts/orchestrator/example-values/README.md
+++ b/charts/orchestrator/example-values/README.md
@@ -38,8 +38,8 @@ starter template.
     
   cloud:
     enabled: true
-    createConfig: true
     config:
+      createConfig: true
       bundlePublicKeyB64: "LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUZrd0V3W="
   ```
 
@@ -53,8 +53,8 @@ starter template.
 
   cloud:
     enabled: true
-    createConfig: true
     config:
+      createConfig: true
       bundlePublicKeyB64: "LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUZrd0V3W="
   ```
 

--- a/charts/orchestrator/example-values/README.md
+++ b/charts/orchestrator/example-values/README.md
@@ -46,10 +46,10 @@ starter template.
   Example of using a secret
   ```
   envValueFrom:
-  MAVERICS_AWS_CONFIG:
-    secretKeyRef:
-      name: storage-provider-secret
-      key: config.json
+    MAVERICS_AWS_CONFIG:
+      secretKeyRef:
+        name: storage-provider-secret
+        key: config.json
 
   cloud:
     enabled: true

--- a/charts/orchestrator/example-values/README.md
+++ b/charts/orchestrator/example-values/README.md
@@ -34,7 +34,7 @@ starter template.
   Example of using inline
   ```
   env: 
-  MAVERICS_AWS_CONFIG: '{"accessKeyID":"my-access-key-id","bucketName":"my-bucket-name","configurationFilePath":"my-configuration-file-path","region":"us-east-2","secretAccessKey":"my-secret-access-key"}'
+     MAVERICS_AWS_CONFIG: '{"accessKeyID":"my-access-key-id","bucketName":"my-bucket-name","configurationFilePath":"my-configuration-file-path","region":"us-east-2","secretAccessKey":"my-secret-access-key"}'
     
   cloud:
     enabled: true

--- a/charts/orchestrator/example-values/minimal-orchestrator-standalone-cloud-local-config.yaml
+++ b/charts/orchestrator/example-values/minimal-orchestrator-standalone-cloud-local-config.yaml
@@ -2,8 +2,8 @@ replicaCount: 1
 
 cloud:
   enabled: true
-  createConfig: true
   config:
+    createConfig: true
     # Base64 encoded environment bundle public key downloaded from Maverics console deployments page.
     # The key can be base64 encoded by running the following:
     #   base64 -i /path/to/env_public_key.pem

--- a/charts/orchestrator/example-values/minimal-orchestrator-standalone-cloud-local-config.yaml
+++ b/charts/orchestrator/example-values/minimal-orchestrator-standalone-cloud-local-config.yaml
@@ -2,8 +2,9 @@ replicaCount: 1
 
 cloud:
   enabled: true
+  createConfig: true
   config:
-    # Base64 encoded environment bundle public key downloaded from Maverics.
+    # Base64 encoded environment bundle public key downloaded from Maverics console deployments page.
     # The key can be base64 encoded by running the following:
     #   base64 -i /path/to/env_public_key.pem
     bundlePublicKeyB64: YmFzZTY0IC1pIC9wYXRoL3RvL2Vudl9wdWJsaWNfa2V5LnBlbQo=

--- a/charts/orchestrator/example-values/minimal-orchestrator-standalone-cloud-s3.yaml
+++ b/charts/orchestrator/example-values/minimal-orchestrator-standalone-cloud-s3.yaml
@@ -1,0 +1,19 @@
+replicaCount: 1
+
+env: 
+  MAVERICS_AWS_CONFIG: '{"accessKeyID":"my-access-key-id","bucketName":"my-bucket-name","configurationFilePath":"my-configuration-file-path","region":"us-east-2","secretAccessKey":"my-secret-access-key"}'
+
+# envValueFrom:
+#   MAVERICS_AWS_CONFIG:
+#     secretKeyRef:
+#       name: storage-provider-secret
+#       key: config.json
+
+cloud:
+  enabled: true
+  createConfig: true
+  config:
+    # Base64 encoded environment bundle public key downloaded from Maverics console deployments page.
+    # The key can be base64 encoded by running the following:
+    #   base64 -i /path/to/env_public_key.pem
+    bundlePublicKeyB64: YmFzZTY0IC1pIC9wYXRoL3RvL2Vudl9wdWJsaWNfa2V5LnBlbQo=

--- a/charts/orchestrator/example-values/minimal-orchestrator-standalone-cloud-s3.yaml
+++ b/charts/orchestrator/example-values/minimal-orchestrator-standalone-cloud-s3.yaml
@@ -11,8 +11,8 @@ env:
 
 cloud:
   enabled: true
-  createConfig: true
   config:
+    createConfig: true
     # Base64 encoded environment bundle public key downloaded from Maverics console deployments page.
     # The key can be base64 encoded by running the following:
     #   base64 -i /path/to/env_public_key.pem

--- a/charts/orchestrator/templates/statefulset.yaml
+++ b/charts/orchestrator/templates/statefulset.yaml
@@ -86,7 +86,7 @@ spec:
             {{- end }}
             {{- range $key, $value := .Values.env }}
             - name: "{{ tpl $key $ }}"
-              value: "{{ tpl (print $value) $ }}"
+              value: {{ tpl ($value | quote) $ }}
             {{- end }}
             {{- range $key, $value := .Values.envValueFrom }}
             - name: {{ $key | quote }}


### PR DESCRIPTION
**Description**

This supports using JSON as an env var

```
env: 
  MAVERICS_AWS_CONFIG: '{"accessKeyID":"my-access-key-id","bucketName":"my-bucket-name","configurationFilePath":"my-configuration-file-path","region":"us-east-2","secretAccessKey":"my-secret-access-key"}'
  
cloud:
  enabled: true
  createConfig: true
  config:
    bundlePublicKeyB64: "LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUZrd0V3W="
```

You can use a pre-created secret to populate this with
```
envValueFrom:
  MAVERICS_AWS_CONFIG:
    secretKeyRef:
      name: storage-provider-secret
      key: config.json
```

You can create the secret with this manifest
```
apiVersion: v1
kind: Secret
metadata:
  name: manual-storage-provider-secret
type: Opaque
stringData:
  config.json: |
    {
      "bucketName": "maverics-development",
      "accessKeyID": "aws-access-key-id",
      "secretAccessKey": "aws-secret-access-key",
      "region": "aws-region",
      "configurationFilePath": "folder1/folder2"
    }
```
**Testing**

This has been tested locally e2e.

**Documentation**