### PR TITLE
Fix chart install failure for Kubernetes versions with build suffixes

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -7,22 +7,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3
         with:
           version: v3.12.2
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: '3.9'
           check-latest: true
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.6.1
+        uses: helm/chart-testing-action@e6669bcd63d7cb57cb4380c33043eebe5d111992 # v2.6.1
 
       - name: Run chart-testing (list-changed)
         id: list-changed
@@ -38,7 +38,7 @@ jobs:
 
       - name: Create kind cluster
         if: steps.list-changed.outputs.changed == 'true'
-        uses: helm/kind-action@v1.7.0
+        uses: helm/kind-action@fa81e57adff234b2908110485695db0f181f3c67 # v1.7.0
 
       # TODO(gramidt): Renanble once we're able to retrieve the Orchestrator image.
       # - name: Run chart-testing (install)

--- a/.github/workflows/redhat-verification.yml
+++ b/.github/workflows/redhat-verification.yml
@@ -10,18 +10,18 @@ jobs:
     name: Verify Helm Chart
     runs-on: ubuntu-20.04
     steps:
-      - uses: redhat-actions/oc-login@v1
+      - uses: redhat-actions/oc-login@5eb45e848b168b6bf6b8fe7f1561003c12e3c99d # v1
         with:
           openshift_server_url: ${{ secrets.OPENSHIFT_SERVER }}
           openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}
 
         # Install chart-verifier CLI
-      - uses: redhat-actions/openshift-tools-installer@v1
+      - uses: redhat-actions/openshift-tools-installer@144527c7d98999f2652264c048c7a9bd103f8a82 # v1
         with:
           source: github
           chart-verifier: latest
 
-      - uses: redhat-actions/chart-verifier@v1.0.0
+      - uses: redhat-actions/chart-verifier@bc6c5c948ccdc6fb5de71d275d300d10f6f39598 # v1.0.0
         with:
           chart_uri: https://github.com/redhat-actions/openshift-actions-runner-chart/blob/release-chart/packages/actions-runner-1.1.tgz?raw=true
           verify_args: --chart-set githubOwner=redhat-actions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 0
 
@@ -20,6 +20,6 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.5.0
+        uses: helm/chart-releaser-action@be16258da8010256c6e82849661221415f031968 # v1.5.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -37,7 +37,7 @@ appVersion: "v2026.01.2"
 # required by RedHat Marketplace for certification of the chart.
 #
 # Before changing this value, please check compatibility with customer deployments.
-kubeVersion: '>=1.24.0'
+kubeVersion: '>=1.24.0-0'
 
 keywords:
   - identity

--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time we
 # make changes to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.2
+version: 1.0.3
 
 # This is the version number of the application being deployed. This version number
 # should be incremented each time we make changes to the application. Versions are


### PR DESCRIPTION
**Description** 
The `kubeVersion` constraint `>=1.24.0` rejects Kubernetes versions with build suffixes like `v1.33.8-eks-3a10415`. Helm treats these suffixes as semver pre-release identifiers, which compare as less than the release version. Changing to `>=1.24.0-0` allows these versions to pass the constraint. This is a no-op for clusters that report clean version strings.

**Testing** 
Verified that `>=1.24.0-0` accepts both plain versions (`1.33.8`) and suffixed versions (`1.33.8-eks-3a10415`), and still correctly rejects versions below 1.24.0.

**Documentation** 
No documentation changes needed.