### PR TITLE
fix: correct orchestrator PDB conditional logic

### DIFF
--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time we
 # make changes to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.3
+version: 1.0.4
 
 # This is the version number of the application being deployed. This version number
 # should be incremented each time we make changes to the application. Versions are

--- a/charts/orchestrator/templates/pdb.yaml
+++ b/charts/orchestrator/templates/pdb.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.podDisruptionBudget.enabled (and .Values.autoscaling.enabled (gt (.Values.autoscaling.minReplicas | int) 1)) (and (not .Values.autoscaling.enabled) (gt (.Values.replicaCount | int) 1)) }}
+{{- if and .Values.podDisruptionBudget.enabled (or (and .Values.autoscaling.enabled (gt (.Values.autoscaling.minReplicas | int) 1)) (and (not .Values.autoscaling.enabled) (gt (.Values.replicaCount | int) 1))) }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:


### PR DESCRIPTION
**Description**

The conditional in `charts/orchestrator/templates/pdb.yaml` combined the autoscaling and replicaCount branches with `and` instead of `or`, requiring `autoscaling.enabled` to be simultaneously `true` and `false`. As a result, the `PodDisruptionBudget` resource never rendered regardless of values.

Before:
```
{{- if and .Values.podDisruptionBudget.enabled (and .Values.autoscaling.enabled (gt ... 1)) (and (not .Values.autoscaling.enabled) (gt ... 1)) }}
```

After:
```
{{- if and .Values.podDisruptionBudget.enabled (or (and .Values.autoscaling.enabled (gt ... 1)) (and (not .Values.autoscaling.enabled) (gt ... 1))) }}
```

**Testing**

`helm lint charts/orchestrator` passes. Verified `helm template` output across all relevant cases:

- `pdb.enabled=true`, `autoscaling.enabled=true`, `minReplicas=2` → PDB renders
- `pdb.enabled=true`, `autoscaling.enabled=true`, `minReplicas=1` → PDB skipped
- `pdb.enabled=true`, `autoscaling.enabled=false`, `replicaCount=2` → PDB renders
- `pdb.enabled=false` → PDB skipped

**Documentation**

N/A — bug fix only; no behavior or values surface changes.

**Issue**

https://maverics.atlassian.net/browse/BIGLIST-1347